### PR TITLE
Fix projection build bug

### DIFF
--- a/server/src/main/java/io/spine/examples/kanban/server/view/BoardProjection.java
+++ b/server/src/main/java/io/spine/examples/kanban/server/view/BoardProjection.java
@@ -28,6 +28,10 @@ import io.spine.examples.kanban.event.BoardCreated;
 import io.spine.examples.kanban.view.BoardView;
 import io.spine.server.projection.Projection;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
 /**
  * Builds display information for a board.
  */
@@ -40,8 +44,13 @@ public final class BoardProjection extends Projection<BoardId, BoardView, BoardV
 
     @Subscribe
     void updated(Column column) {
-        int index = state().getColumnList()
-                           .indexOf(column);
+        // Find index of the column in the board by matching a column id.
+        // We can't rely on `equals` method of the column case it was updated.
+        int index = indexOf(
+                state().getColumnList(),
+                (c) -> Objects.equals(c.getId(), column.getId())
+        );
+
         if (index != -1) {
             builder().setColumn(index, column);
         } else {
@@ -58,5 +67,24 @@ public final class BoardProjection extends Projection<BoardId, BoardView, BoardV
         } else {
             builder().addCard(card);
         }
+    }
+
+    /**
+     * Finds an index of needed element in the list by testing each element with
+     * a specified predicate.
+     *
+     * @param list
+     *         of elements to search in
+     * @param predicate
+     *         that tests whether a specified element is needed
+     * @return an integer index of the found element if it was found or -1 otherwise
+     */
+    private static <T> int indexOf(List<T> list, Predicate<T> predicate) {
+        for (int i = 0; i < list.size(); i++) {
+            if (predicate.test(list.get(i))) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/TestCommands.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/TestCommands.java
@@ -65,7 +65,7 @@ final class TestCommands {
                 .newBuilder()
                 .setCard(card)
                 .setBoard(board)
-                .setName("Generated card " + randomString())
+                .setName("Generated card " + card.getUuid())
                 .vBuild();
     }
 

--- a/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
@@ -125,7 +125,6 @@ class BoardProjectionTest extends KanbanContextTest {
     @Test
     @DisplayName("has cards in columns")
     void hasCardsInColumns() {
-
         List<Card> expectedCards = IntStream.range(0, 3)
                                             .mapToObj(i -> {
                                                 CardId cardId = CardId.generate();


### PR DESCRIPTION
This PR fixes issues related to the `BoardProjection` build on handling columns update.
**Old behavior**: On a column update, a subscriber in the `BoardProjection` will add a new column in the board.
**New behavior**: When column updates an old column in the board columns list will be replaced with an updated one.