### PR TITLE
Update to Spine `1.2.0`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
  */
 
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '1.1.4' apply false
+    id 'io.spine.tools.gradle.bootstrap' version '1.2.0' apply false
     id 'net.ltgt.errorprone' version '1.1.1' apply false
 }
 

--- a/version.gradle
+++ b/version.gradle
@@ -24,7 +24,7 @@ final def versions = [
         guava           : "28.1-jre",
         checkerFramework: "2.11.1",
         apiGuardian     : "1.1.0",
-        grpc            : "1.23.0",
+        grpc            : "1.24.1",
         pmd             : "6.16.0",
 
         junit5          : "5.5.2",


### PR DESCRIPTION
This PR updates the example to Spine of version `1.2.0`.

It also bumps some of the dependencies to match what's used in Spine `1.2.0`.