### PR TITLE
Bump versions

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/examples/kanban/dependency/CheckerFramework.kt
+++ b/buildSrc/src/main/kotlin/io/spine/examples/kanban/dependency/CheckerFramework.kt
@@ -28,6 +28,6 @@ package io.spine.examples.kanban.dependency
 
 // https://checkerframework.org/
 object CheckerFramework {
-    const val version = "3.21.0"
+    const val version = "3.22.2"
     const val lib = "org.checkerframework:checker-qual:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/examples/kanban/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/examples/kanban/dependency/ErrorProne.kt
@@ -31,7 +31,7 @@ object ErrorProne {
     private const val group = "com.google.errorprone"
 
     object CorePlugin {
-        const val version = "2.4.0"
+        const val version = "2.10.0"
         const val lib = "${group}:error_prone_core:${version}"
     }
 

--- a/buildSrc/src/main/kotlin/io/spine/examples/kanban/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/examples/kanban/dependency/Grpc.kt
@@ -28,6 +28,6 @@ package io.spine.examples.kanban.dependency
 
 // https://github.com/grpc/grpc-java
 object Grpc {
-    const val version = "1.28.1"
+    const val version = "1.47.0"
     const val lib = "io.grpc:grpc-netty:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/examples/kanban/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/examples/kanban/dependency/Guava.kt
@@ -28,6 +28,6 @@ package io.spine.examples.kanban.dependency
 
 // https://github.com/google/guava
 object Guava {
-    const val version = "31.0.1-jre"
+    const val version = "31.1-jre"
     const val lib = "com.google.guava:guava:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/examples/kanban/dependency/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/examples/kanban/dependency/Pmd.kt
@@ -28,5 +28,5 @@ package io.spine.examples.kanban.dependency
 
 // https://pmd.github.io/
 object Pmd {
-    const val version = "6.41.0"
+    const val version = "6.47.0"
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.spine.protobuf.AnyPacker.unpack;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @DisplayName("BoardProjection should")
 class BoardProjectionTest extends KanbanContextTest {
@@ -85,6 +86,9 @@ class BoardProjectionTest extends KanbanContextTest {
                                        .setId(c)
                                        .build())
                        .collect(toImmutableList());
+
+        assertFalse(expectedColumns.isEmpty());
+
         BoardView expected = BoardView
                 .newBuilder()
                 .setId(board())

--- a/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
@@ -67,7 +67,7 @@ class BoardProjectionTest extends KanbanContextTest {
     }
 
     @Test
-    @DisplayName("has the state with the ID of the board")
+    @DisplayName("have the state with the ID of the board")
     void id() {
         entityState.isInstanceOf(BoardView.class);
         entityState.comparingExpectedFieldsOnly()
@@ -77,7 +77,7 @@ class BoardProjectionTest extends KanbanContextTest {
     }
 
     @Test
-    @DisplayName("has columns")
+    @DisplayName("have columns")
     void columns() {
         List<Column> expectedColumns =
                 columns.stream()
@@ -96,7 +96,7 @@ class BoardProjectionTest extends KanbanContextTest {
     }
 
     @Test
-    @DisplayName("has cards")
+    @DisplayName("have cards")
     void cards() {
         List<Card> expectedCards =
                 cards.stream()
@@ -124,7 +124,7 @@ class BoardProjectionTest extends KanbanContextTest {
                 .assertCommands()
                 .actual()
                 .stream()
-                .filter(commandClass::isInstance)
+                .filter(c -> c.is(commandClass))
                 .map(c -> unpack(c.getMessage(), commandClass));
     }
 }


### PR DESCRIPTION
### Main changes
This PR bumps versions of dependencies. 

### Additional changes
Also, a bug has been found in `BoardProjectionTest`. There is a method to retrieve a list of all commands of a specific type that were processed by a bounded context. This method worked improperly, because of the incorrect filtering logic, and always returned an empty list. As the list is used to create an expected state of an entity after processing all these commands, all tests were asserting against the wrong expected state. However, due to implementation details of comparison of an actual and expected states, tests were passing. This PR fixes the issue.