### PR TITLE
Update `Build` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
+    - uses: actions/checkout@v3
 
-    - name: Run tests with Gradle
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+
+    - name: Build and run tests
       run: ./gradlew build --stacktrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '8'
+        distribution: zulu
+        cache: 'gradle'
 
     - name: Build and run tests
       run: ./gradlew build --stacktrace


### PR DESCRIPTION
This PR bumps versions of GitHub Actions used in the `Build` workflow. Also, it takes leverage of caching Gradle dependencies between workflow runs [provided](https://github.com/actions/setup-java#caching-packages-dependencies) by the new version of the `setup-java` action.