### PR TITLE
Fix issue with creating "Unrecognized" column during board initialization

### DIFF
--- a/server/src/main/java/io/spine/examples/kanban/server/board/DefaultColumns.java
+++ b/server/src/main/java/io/spine/examples/kanban/server/board/DefaultColumns.java
@@ -68,11 +68,11 @@ final class DefaultColumns {
         DefaultColumn[] columns = DefaultColumn.values();
         int total = columns.length - 1;
 
-        for (int i = 1; i <= total; i++) {
-            DefaultColumn column = columns[i];
+        for (int oneBasedIndex = 1; oneBasedIndex <= total; oneBasedIndex++) {
+            DefaultColumn column = columns[oneBasedIndex - 1];
             ColumnPosition position =
                     ColumnPosition.newBuilder()
-                                  .setIndex(i)
+                                  .setIndex(oneBasedIndex)
                                   .setOfTotal(total)
                                   .vBuild();
 

--- a/server/src/test/java/io/spine/examples/kanban/server/KanbanTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/KanbanTest.java
@@ -56,7 +56,9 @@ public abstract class KanbanTest {
                        .vBuild();
     }
 
-    /** Creates a column position with the passed index and total number of columns. */
+    /**
+     * Creates a column position with the passed index and total number of columns.
+     */
     public static ColumnPosition columnPosition(int index, int ofTotal) {
         return ColumnPosition.newBuilder()
                              .setIndex(index)

--- a/server/src/test/java/io/spine/examples/kanban/server/board/AddColumnCommands.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/AddColumnCommands.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.kanban.server.board;
+
+import io.spine.examples.kanban.Column;
+import io.spine.examples.kanban.command.AddColumn;
+
+/**
+ * Provides utility methods for {@link AddColumn} for testing purposes.
+ */
+final class AddColumnCommands {
+
+    /**
+     * Prevents utility class instantiation.
+     */
+    private AddColumnCommands() {
+
+    }
+
+    /**
+     * Clears the column's ID.
+     */
+    static AddColumn clearId(AddColumn c) {
+        return c.toBuilder()
+                .clearColumn()
+                .buildPartial();
+    }
+}

--- a/server/src/test/java/io/spine/examples/kanban/server/board/AddColumnCommands.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/AddColumnCommands.java
@@ -38,7 +38,6 @@ final class AddColumnCommands {
      * Prevents utility class instantiation.
      */
     private AddColumnCommands() {
-
     }
 
     /**

--- a/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
@@ -31,6 +31,7 @@ import io.spine.examples.kanban.Column;
 import io.spine.examples.kanban.command.AddColumn;
 import io.spine.examples.kanban.event.BoardInitialized;
 import io.spine.examples.kanban.server.KanbanContextTest;
+import io.spine.examples.kanban.server.board.given.AddColumnCommands;
 import io.spine.testing.server.CommandSubject;
 import io.spine.testing.server.EventSubject;
 import org.junit.jupiter.api.BeforeEach;

--- a/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
@@ -29,7 +29,6 @@ package io.spine.examples.kanban.server.board;
 import com.google.common.collect.ImmutableList;
 import io.spine.examples.kanban.Column;
 import io.spine.examples.kanban.command.AddColumn;
-import io.spine.examples.kanban.command.CreateColumn;
 import io.spine.examples.kanban.event.BoardInitialized;
 import io.spine.examples.kanban.server.KanbanContextTest;
 import io.spine.testing.server.CommandSubject;
@@ -60,7 +59,7 @@ class BoardInitProcessTest extends KanbanContextTest {
         ImmutableList<AddColumn> expectedCommands =
                 DefaultColumns.additionCommands(board())
                               .stream()
-                              .map(BoardInitProcessTest::clearId)
+                              .map(AddColumnCommands::clearId)
                               .collect(toImmutableList());
 
         for (int i = 0; i < expectedCount; i++) {
@@ -70,11 +69,6 @@ class BoardInitProcessTest extends KanbanContextTest {
         }
     }
 
-    private static AddColumn clearId(AddColumn c) {
-        return c.toBuilder()
-                .clearColumn()
-                .buildPartial();
-    }
 
     @Test
     @DisplayName("add default columns")

--- a/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
@@ -59,17 +59,32 @@ class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
     @DisplayName("produce commands to add 'To Do', 'In Progress', 'Review' and 'Done' columns")
     void additionCommandsProducesRightCommands() {
         BoardId board = BoardId.generate();
-        AddColumn toDo = additionCommand(board, "To Do", position(1,4));
-        AddColumn inProgress = additionCommand(board, "In Progress", position(2,4));
-        AddColumn review = additionCommand(board, "Review", position(3,4));
-        AddColumn done = additionCommand(board, "Done", position(4,4));
-        ImmutableList<AddColumn> expected = ImmutableList.of(toDo, inProgress, review, done);
-        ImmutableList<AddColumn> actual = DefaultColumns.additionCommands(board)
-                                                        .stream()
-                                                        .map(AddColumnCommands::clearId)
-                                                        .collect(toImmutableList());
+        ImmutableList<AddColumn> expected = expectedAdditionCommands(board);
+        ImmutableList<AddColumn> actual =
+                DefaultColumns.additionCommands(board)
+                              .stream()
+                              .map(AddColumnCommands::clearId)
+                              .collect(toImmutableList());
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    /**
+     * Returns the expected list of commands for adding defaults columns to the
+     * provided board that should completely match the output list from the
+     * {@link DefaultColumns#additionCommands(BoardId)} considering both methods get
+     * the same input.
+     *
+     * <p> Produced commands do not have column IDs as they are supposed to be used
+     * for comparison with an actual output of the mentioned method.
+     */
+    private static ImmutableList<AddColumn> expectedAdditionCommands(BoardId board) {
+        AddColumn toDo = additionCommand(board, "To Do", position(1, 4));
+        AddColumn inProgress = additionCommand(board, "In Progress", position(2, 4));
+        AddColumn review = additionCommand(board, "Review", position(3, 4));
+        AddColumn done = additionCommand(board, "Done", position(4, 4));
+
+        return ImmutableList.of(toDo, inProgress, review, done);
     }
 
     private static AddColumn additionCommand(

--- a/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import io.spine.examples.kanban.BoardId;
 import io.spine.examples.kanban.ColumnPosition;
 import io.spine.examples.kanban.command.AddColumn;
+import io.spine.examples.kanban.server.board.given.AddColumnCommands;
 import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
@@ -59,54 +59,10 @@ class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
     @DisplayName("produce commands to add 'To Do', 'In Progress', 'Review' and 'Done' columns")
     void additionCommandsProducesRightCommands() {
         BoardId board = BoardId.generate();
-        AddColumn toDo =
-                AddColumn.newBuilder()
-                         .setBoard(board)
-                         .setName("To Do")
-                         .setDesiredPosition(
-                                 ColumnPosition.newBuilder()
-                                               .setIndex(1)
-                                               .setOfTotal(4)
-                                               .vBuild()
-                         )
-                         .buildPartial();
-
-        AddColumn inProgress =
-                AddColumn.newBuilder()
-                         .setBoard(board)
-                         .setName("In Progress")
-                         .setDesiredPosition(
-                                 ColumnPosition.newBuilder()
-                                               .setIndex(2)
-                                               .setOfTotal(4)
-                                               .vBuild()
-                         )
-                         .buildPartial();
-
-        AddColumn review =
-                AddColumn.newBuilder()
-                         .setBoard(board)
-                         .setName("Review")
-                         .setDesiredPosition(
-                                 ColumnPosition.newBuilder()
-                                               .setIndex(3)
-                                               .setOfTotal(4)
-                                               .vBuild()
-                         )
-                         .buildPartial();
-
-        AddColumn done =
-                AddColumn.newBuilder()
-                         .setBoard(board)
-                         .setName("Done")
-                         .setDesiredPosition(
-                                 ColumnPosition.newBuilder()
-                                               .setIndex(4)
-                                               .setOfTotal(4)
-                                               .vBuild()
-                         )
-                         .buildPartial();
-
+        AddColumn toDo = additionCommand(board, "To Do", position(1,4));
+        AddColumn inProgress = additionCommand(board, "In Progress", position(2,4));
+        AddColumn review = additionCommand(board, "Review", position(3,4));
+        AddColumn done = additionCommand(board, "Done", position(4,4));
         ImmutableList<AddColumn> expected = ImmutableList.of(toDo, inProgress, review, done);
         ImmutableList<AddColumn> actual = DefaultColumns.additionCommands(board)
                                                         .stream()
@@ -114,5 +70,26 @@ class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
                                                         .collect(toImmutableList());
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    private static AddColumn additionCommand(
+            BoardId board,
+            String name,
+            ColumnPosition position
+    ) {
+        return AddColumn
+                .newBuilder()
+                .setBoard(board)
+                .setName(name)
+                .setDesiredPosition(position)
+                .buildPartial();
+    }
+
+    private static ColumnPosition position(int index, int ofTotal) {
+        return ColumnPosition
+                .newBuilder()
+                .setIndex(index)
+                .setOfTotal(ofTotal)
+                .vBuild();
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
@@ -35,8 +35,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
 import static io.spine.examples.kanban.BoardInit.DefaultColumn;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("`DefaultColumns` should")
 class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
@@ -51,7 +51,8 @@ class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
         String expected = "To Do";
         String actual = DefaultColumns.nameFor(DefaultColumn.TO_DO);
 
-        assertEquals(expected, actual);
+        assertThat(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -112,6 +113,6 @@ class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
                                                         .map(AddColumnCommands::clearId)
                                                         .collect(toImmutableList());
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
@@ -51,8 +51,7 @@ class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
         String expected = "To Do";
         String actual = DefaultColumns.nameFor(DefaultColumn.TO_DO);
 
-        assertThat(actual)
-                .isEqualTo(expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
@@ -26,11 +26,17 @@
 
 package io.spine.examples.kanban.server.board;
 
-import io.spine.examples.kanban.BoardInit;
+import com.google.common.collect.ImmutableList;
+import io.spine.examples.kanban.BoardId;
+import io.spine.examples.kanban.ColumnPosition;
+import io.spine.examples.kanban.command.AddColumn;
 import io.spine.testing.UtilityClassTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.spine.examples.kanban.BoardInit.DefaultColumn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("`DefaultColumns` should")
 class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
@@ -43,8 +49,69 @@ class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
     @DisplayName("convert an enum value to the Title Case")
     void nameForConvertsToTitleCase() {
         String expected = "To Do";
-        String actual = DefaultColumns.nameFor(BoardInit.DefaultColumn.TO_DO);
+        String actual = DefaultColumns.nameFor(DefaultColumn.TO_DO);
 
-        Assertions.assertEquals(expected, actual);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("produce commands to add 'To Do', 'In Progress', 'Review' and 'Done' columns")
+    void additionCommandsProducesRightCommands() {
+        BoardId board = BoardId.generate();
+        AddColumn toDo =
+                AddColumn.newBuilder()
+                         .setBoard(board)
+                         .setName("To Do")
+                         .setDesiredPosition(
+                                 ColumnPosition.newBuilder()
+                                               .setIndex(1)
+                                               .setOfTotal(4)
+                                               .vBuild()
+                         )
+                         .buildPartial();
+
+        AddColumn inProgress =
+                AddColumn.newBuilder()
+                         .setBoard(board)
+                         .setName("In Progress")
+                         .setDesiredPosition(
+                                 ColumnPosition.newBuilder()
+                                               .setIndex(2)
+                                               .setOfTotal(4)
+                                               .vBuild()
+                         )
+                         .buildPartial();
+
+        AddColumn review =
+                AddColumn.newBuilder()
+                         .setBoard(board)
+                         .setName("Review")
+                         .setDesiredPosition(
+                                 ColumnPosition.newBuilder()
+                                               .setIndex(3)
+                                               .setOfTotal(4)
+                                               .vBuild()
+                         )
+                         .buildPartial();
+
+        AddColumn done =
+                AddColumn.newBuilder()
+                         .setBoard(board)
+                         .setName("Done")
+                         .setDesiredPosition(
+                                 ColumnPosition.newBuilder()
+                                               .setIndex(4)
+                                               .setOfTotal(4)
+                                               .vBuild()
+                         )
+                         .buildPartial();
+
+        ImmutableList<AddColumn> expected = ImmutableList.of(toDo, inProgress, review, done);
+        ImmutableList<AddColumn> actual = DefaultColumns.additionCommands(board)
+                                                        .stream()
+                                                        .map(AddColumnCommands::clearId)
+                                                        .collect(toImmutableList());
+
+        assertEquals(expected, actual);
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.examples.kanban.BoardInit.DefaultColumn;
+import static io.spine.examples.kanban.server.KanbanTest.columnPosition;
 
 @DisplayName("`DefaultColumns` should")
 class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
@@ -78,10 +79,10 @@ class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
      * for comparison with an actual output of the mentioned method.
      */
     private static ImmutableList<AddColumn> expectedAdditionCommands(BoardId board) {
-        AddColumn toDo = additionCommand(board, "To Do", position(1, 4));
-        AddColumn inProgress = additionCommand(board, "In Progress", position(2, 4));
-        AddColumn review = additionCommand(board, "Review", position(3, 4));
-        AddColumn done = additionCommand(board, "Done", position(4, 4));
+        AddColumn toDo = additionCommand(board, "To Do", columnPosition(1, 4));
+        AddColumn inProgress = additionCommand(board, "In Progress", columnPosition(2, 4));
+        AddColumn review = additionCommand(board, "Review", columnPosition(3, 4));
+        AddColumn done = additionCommand(board, "Done", columnPosition(4, 4));
 
         return ImmutableList.of(toDo, inProgress, review, done);
     }
@@ -97,13 +98,5 @@ class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
                 .setName(name)
                 .setDesiredPosition(position)
                 .buildPartial();
-    }
-
-    private static ColumnPosition position(int index, int ofTotal) {
-        return ColumnPosition
-                .newBuilder()
-                .setIndex(index)
-                .setOfTotal(ofTotal)
-                .vBuild();
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/board/given/AddColumnCommands.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/given/AddColumnCommands.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.kanban.server.board.given;
+
+import io.spine.examples.kanban.command.AddColumn;
+
+/**
+ * Provides utility methods for {@link AddColumn} for testing purposes.
+ */
+public final class AddColumnCommands {
+
+    /**
+     * Prevents utility class instantiation.
+     */
+    private AddColumnCommands() {
+    }
+
+    /**
+     * Clears the column's ID.
+     */
+    public static AddColumn clearId(AddColumn c) {
+        return c.toBuilder()
+                .clearColumn()
+                .buildPartial();
+    }
+}

--- a/server/src/test/java/io/spine/examples/kanban/server/board/given/package-info.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/given/package-info.java
@@ -24,28 +24,14 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.kanban.server.board;
-
-import io.spine.examples.kanban.Column;
-import io.spine.examples.kanban.command.AddColumn;
-
 /**
- * Provides utility methods for {@link AddColumn} for testing purposes.
+ * Test environment classes for testing the {@link io.spine.examples.kanban.server} package.
  */
-final class AddColumnCommands {
 
-    /**
-     * Prevents utility class instantiation.
-     */
-    private AddColumnCommands() {
-    }
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.examples.kanban.server.board.given;
 
-    /**
-     * Clears the column's ID.
-     */
-    static AddColumn clearId(AddColumn c) {
-        return c.toBuilder()
-                .clearColumn()
-                .buildPartial();
-    }
-}
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
This PR removes the creation of the "Unrecognized" column during board initialization. The column is created instead of the "To Do". It happens due to improper processing of the `DefaultColumn` enum during assembling commands for adding default columns. 

Also, the PR adds a test to prove that the issue is resolved. The test checks that the `DefaultColumns.additionCommands()` method produces commands to add default columns in the following order: "To Do", "In Progress", "Review", "Done".