### PR TITLE
Refactor `server` tests

### DIFF
--- a/server/src/test/java/io/spine/examples/kanban/server/KanbanContextTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/KanbanContextTest.java
@@ -26,11 +26,18 @@
 
 package io.spine.examples.kanban.server;
 
+import io.spine.base.CommandMessage;
+import io.spine.base.EventMessage;
+import io.spine.testing.server.CommandSubject;
+import io.spine.testing.server.EventSubject;
 import io.spine.testing.server.blackbox.BlackBoxContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
+import java.util.stream.Stream;
+
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.protobuf.AnyPacker.unpack;
 
 /**
  * Abstract base for tests in Kanban Bounded Context.
@@ -51,5 +58,35 @@ public abstract class KanbanContextTest extends KanbanTest {
 
     protected BlackBoxContext context() {
         return checkNotNull(context);
+    }
+
+    /**
+     * Check commands of the provided type received by the bounded context during tests.
+     */
+    protected final <T extends CommandMessage> CommandSubject assertCommands(Class<T> commandClass) {
+        return context()
+                .assertCommands()
+                .withType(commandClass);
+    }
+
+    /**
+     * Stream commands of the provided type received by the bounded context during tests.
+     */
+    protected final <T extends CommandMessage> Stream<T> receivedCommands(Class<T> commandClass) {
+        return context()
+                .assertCommands()
+                .withType(commandClass)
+                .actual()
+                .stream()
+                .map(c -> unpack(c.getMessage(), commandClass));
+    }
+
+    /**
+     * Check events of the provided type emitted by the bounded context during tests.
+     */
+    protected final <T extends EventMessage> EventSubject assertEvents(Class<T> eventClass) {
+        return context()
+                .assertEvents()
+                .withType(eventClass);
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/KanbanContextTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/KanbanContextTest.java
@@ -61,7 +61,7 @@ public abstract class KanbanContextTest extends KanbanTest {
     }
 
     /**
-     * Check commands of the provided type received by the bounded context during tests.
+     * Checks for commands of the provided type received by the bounded context under the test.
      */
     protected final <T extends CommandMessage> CommandSubject assertCommands(Class<T> commandClass) {
         return context()
@@ -70,7 +70,7 @@ public abstract class KanbanContextTest extends KanbanTest {
     }
 
     /**
-     * Stream commands of the provided type received by the bounded context during tests.
+     * Streams commands of the provided type received by the bounded context during tests.
      */
     protected final <T extends CommandMessage> Stream<T> receivedCommands(Class<T> commandClass) {
         return context()
@@ -82,7 +82,7 @@ public abstract class KanbanContextTest extends KanbanTest {
     }
 
     /**
-     * Check events of the provided type emitted by the bounded context during tests.
+     * Checks for events of the provided type emitted by the bounded context under the test.
      */
     protected final <T extends EventMessage> EventSubject assertEvents(Class<T> eventClass) {
         return context()

--- a/server/src/test/java/io/spine/examples/kanban/server/KanbanServerTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/KanbanServerTest.java
@@ -39,10 +39,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.spine.client.ConnectionConstants.DEFAULT_CLIENT_SERVICE_PORT;
 import static io.spine.examples.kanban.server.given.TestCommands.createBoard;
 import static io.spine.testing.core.given.GivenUserId.newUuid;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -58,7 +58,7 @@ class KanbanServerTest {
     private BoardId boardId;
 
     @BeforeEach
-    void setup(){
+    void setup() {
         server = KanbanServer.create();
         client = new TestClient(newUuid(), HOST, DEFAULT_CLIENT_SERVICE_PORT);
         startServer();
@@ -89,7 +89,7 @@ class KanbanServerTest {
             client.post(createBoard(boardId));
 
             QueryResponse response = client.queryAll(Board.class);
-            assertEquals(1, response.getMessageCount());
+            assertThat(response.getMessageCount()).isEqualTo(1);
         }
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/KanbanServerTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/KanbanServerTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static io.spine.client.ConnectionConstants.DEFAULT_CLIENT_SERVICE_PORT;
-import static io.spine.examples.kanban.server.TestCommands.createBoard;
+import static io.spine.examples.kanban.server.given.TestCommands.createBoard;
 import static io.spine.testing.core.given.GivenUserId.newUuid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/server/src/test/java/io/spine/examples/kanban/server/KanbanTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/KanbanTest.java
@@ -95,7 +95,7 @@ public abstract class KanbanTest {
         return TestCommands.createCard(board, card);
     }
 
-    protected static SetWipLimit setWipLimit(ColumnId column, int limit) {
+    protected static SetWipLimit setWipLimit(ColumnId column, WipLimit limit) {
         return TestCommands.setWipLimit(column, limit);
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/KanbanTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/KanbanTest.java
@@ -35,6 +35,7 @@ import io.spine.examples.kanban.command.AddColumn;
 import io.spine.examples.kanban.command.CreateBoard;
 import io.spine.examples.kanban.command.CreateCard;
 import io.spine.examples.kanban.command.SetWipLimit;
+import io.spine.examples.kanban.server.given.TestCommands;
 import org.junit.jupiter.api.BeforeEach;
 
 /**

--- a/server/src/test/java/io/spine/examples/kanban/server/KanbanTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/KanbanTest.java
@@ -35,6 +35,7 @@ import io.spine.examples.kanban.command.AddColumn;
 import io.spine.examples.kanban.command.CreateBoard;
 import io.spine.examples.kanban.command.CreateCard;
 import io.spine.examples.kanban.command.SetWipLimit;
+import io.spine.examples.kanban.server.given.ColumnPositions;
 import io.spine.examples.kanban.server.given.TestCommands;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -45,7 +46,7 @@ public abstract class KanbanTest {
 
     private BoardId board;
     private ColumnId column;
-    private final ColumnPosition defaultPosition = columnPosition(1, 1);
+    private final ColumnPosition defaultPosition = ColumnPositions.of(1, 1);
     private CardId card;
 
     /**
@@ -55,16 +56,6 @@ public abstract class KanbanTest {
         return WipLimit.newBuilder()
                        .setValue(limit)
                        .vBuild();
-    }
-
-    /**
-     * Creates a column position with the passed index and total number of columns.
-     */
-    public static ColumnPosition columnPosition(int index, int ofTotal) {
-        return ColumnPosition.newBuilder()
-                             .setIndex(index)
-                             .setOfTotal(ofTotal)
-                             .vBuild();
     }
 
     /**

--- a/server/src/test/java/io/spine/examples/kanban/server/KanbanTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/KanbanTest.java
@@ -50,15 +50,6 @@ public abstract class KanbanTest {
     private CardId card;
 
     /**
-     * Creates a limit instance with the passed value.
-     */
-    public static WipLimit wipLimit(int limit) {
-        return WipLimit.newBuilder()
-                       .setValue(limit)
-                       .vBuild();
-    }
-
-    /**
      * Generates identifiers used by the test suite.
      */
     @BeforeEach

--- a/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
@@ -44,7 +44,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 class BoardInitProcessTest extends KanbanContextTest {
 
     @BeforeEach
-    void sendCommand() {
+    void setupBoard() {
         context().receivesCommand(createBoard());
     }
 

--- a/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
@@ -52,10 +52,9 @@ class BoardInitProcessTest extends KanbanContextTest {
     @Test
     @DisplayName("issue addition commands for all default columns")
     void issuesCommands() {
-        CommandSubject issuedCommands = context().assertCommands()
-                                                 .withType(AddColumn.class);
+        CommandSubject assertCommands = assertCommands(AddColumn.class);
         int expectedCount = DefaultColumns.count();
-        issuedCommands.hasSize(expectedCount);
+        assertCommands.hasSize(expectedCount);
 
         ImmutableList<AddColumn> expectedCommands =
                 DefaultColumns.additionCommands(board())
@@ -64,12 +63,11 @@ class BoardInitProcessTest extends KanbanContextTest {
                               .collect(toImmutableList());
 
         for (int i = 0; i < expectedCount; i++) {
-            issuedCommands.message(i)
+            assertCommands.message(i)
                           .comparingExpectedFieldsOnly()
                           .isEqualTo(expectedCommands.get(i));
         }
     }
-
 
     @Test
     @DisplayName("add default columns")
@@ -84,13 +82,9 @@ class BoardInitProcessTest extends KanbanContextTest {
     }
 
     private ImmutableList<Column> expectedColumns() {
-        return context().assertCommands()
-                        .withType(AddColumn.class)
-                        .actual()
-                        .stream()
-                        .map(c -> unpack(c.getMessage(), AddColumn.class))
-                        .map(BoardInitProcessTest::toColumn)
-                        .collect(toImmutableList());
+        return receivedCommands(AddColumn.class)
+                .map(BoardInitProcessTest::toColumn)
+                .collect(toImmutableList());
     }
 
     private static Column toColumn(AddColumn c) {
@@ -105,14 +99,14 @@ class BoardInitProcessTest extends KanbanContextTest {
     @Test
     @DisplayName("emit the `BoardInitialized` event when terminated")
     void emitsEvent() {
-        EventSubject events = context().assertEvents()
-                                       .withType(BoardInitialized.class);
-        events.hasSize(1);
-        BoardInitialized expected = BoardInitialized
-                .newBuilder()
-                .setBoard(board())
-                .vBuild();
-        events.message(0)
+        EventSubject assertEvents = assertEvents(BoardInitialized.class);
+        assertEvents.hasSize(1);
+
+        BoardInitialized expected =
+                BoardInitialized.newBuilder()
+                                .setBoard(board())
+                                .vBuild();
+        assertEvents.message(0)
               .comparingExpectedFieldsOnly()
               .isEqualTo(expected);
     }

--- a/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.spine.protobuf.AnyPacker.unpack;
 
 @DisplayName("BoardInitProcess should")
 class BoardInitProcessTest extends KanbanContextTest {
@@ -72,19 +71,9 @@ class BoardInitProcessTest extends KanbanContextTest {
     @Test
     @DisplayName("add default columns")
     void addsColumns() {
-        ImmutableList<Column> expectedColumns = expectedColumns();
-        expectedColumns.forEach(
-                c -> context().assertEntityWithState(c.getId(), Column.class)
-                              .hasStateThat()
-                              .comparingExpectedFieldsOnly()
-                              .isEqualTo(c)
-        );
-    }
-
-    private ImmutableList<Column> expectedColumns() {
-        return receivedCommands(AddColumn.class)
+        receivedCommands(AddColumn.class)
                 .map(BoardInitProcessTest::toColumn)
-                .collect(toImmutableList());
+                .forEach(this::assertColumnExists);
     }
 
     private static Column toColumn(AddColumn c) {
@@ -95,6 +84,15 @@ class BoardInitProcessTest extends KanbanContextTest {
                 .setName(c.getName())
                 .vBuild();
     }
+
+    private void assertColumnExists(Column column) {
+        context().assertEntityWithState(column.getId(), Column.class)
+                 .hasStateThat()
+                 .comparingExpectedFieldsOnly()
+                 .isEqualTo(column);
+    }
+
+
 
     @Test
     @DisplayName("emit the `BoardInitialized` event when terminated")
@@ -107,8 +105,8 @@ class BoardInitProcessTest extends KanbanContextTest {
                                 .setBoard(board())
                                 .vBuild();
         assertEvents.message(0)
-              .comparingExpectedFieldsOnly()
-              .isEqualTo(expected);
+                    .comparingExpectedFieldsOnly()
+                    .isEqualTo(expected);
     }
 
     @Test

--- a/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/BoardInitProcessTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
-@DisplayName("BoardInitProcess should")
+@DisplayName("`BoardInitProcess` should")
 class BoardInitProcessTest extends KanbanContextTest {
 
     @BeforeEach

--- a/server/src/test/java/io/spine/examples/kanban/server/board/BoardTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/BoardTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 import static io.spine.examples.kanban.rejection.Rejections.ColumnNameAlreadyTaken;
 import static io.spine.testing.TestValues.randomString;
 
-@DisplayName("Kanban Context Board logic should")
+@DisplayName("`Board` should")
 @Ignore("Restore the tests when move card API is defined")
 class BoardTest extends KanbanContextTest {
 
@@ -114,7 +114,7 @@ class BoardTest extends KanbanContextTest {
         }
 
         @Test
-        @DisplayName("by rejecting the addition of the column with a duplicate name")
+        @DisplayName("by rejecting addition of the column with a duplicate name")
         void rejection() {
             EventSubject assertRejections = assertEvents(ColumnNameAlreadyTaken.class);
             assertRejections.hasSize(1);
@@ -123,14 +123,14 @@ class BoardTest extends KanbanContextTest {
                     ColumnNameAlreadyTaken.newBuilder()
                                           .setColumn(rejectedCommand.getColumn())
                                           .setName(rejectedCommand.getName())
-                                          .build();
+                                          .vBuild();
             assertRejections.message(0)
                             .isEqualTo(expected);
         }
     }
 
     @Nested
-    @DisplayName("Move card emitting")
+    @DisplayName("move card emitting")
     class MoveCard {
 
         @BeforeEach

--- a/server/src/test/java/io/spine/examples/kanban/server/board/BoardTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/BoardTest.java
@@ -32,6 +32,7 @@ import io.spine.examples.kanban.ColumnPosition;
 import io.spine.examples.kanban.command.AddColumn;
 import io.spine.examples.kanban.event.BoardCreated;
 import io.spine.examples.kanban.server.KanbanContextTest;
+import io.spine.examples.kanban.server.given.ColumnPositions;
 import io.spine.testing.server.EventSubject;
 import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,7 +87,7 @@ class BoardTest extends KanbanContextTest {
         @BeforeEach
         void sendCommands() {
             String name = randomString();
-            ColumnPosition position = columnPosition(
+            ColumnPosition position = ColumnPositions.of(
                     DefaultColumns.count() + 1,
                     DefaultColumns.count() + 1
             );
@@ -97,7 +98,7 @@ class BoardTest extends KanbanContextTest {
                              .setName(name)
                              .setDesiredPosition(position)
                              .vBuild();
-            position = columnPosition(
+            position = ColumnPositions.of(
                     DefaultColumns.count() + 2,
                     DefaultColumns.count() + 2
             );

--- a/server/src/test/java/io/spine/examples/kanban/server/board/BoardTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/BoardTest.java
@@ -71,10 +71,9 @@ class BoardTest extends KanbanContextTest {
                                 .setBoard(board())
                                 .build();
 
-            context().assertEvents()
-                     .withType(BoardCreated.class)
-                     .message(0)
-                     .isEqualTo(expected);
+            assertEvents(BoardCreated.class)
+                    .message(0)
+                    .isEqualTo(expected);
         }
     }
 
@@ -102,12 +101,13 @@ class BoardTest extends KanbanContextTest {
                     DefaultColumns.count() + 2,
                     DefaultColumns.count() + 2
             );
-            rejectedCommand = AddColumn.newBuilder()
-                                       .setBoard(board())
-                                       .setColumn(ColumnId.generate())
-                                       .setName(name)
-                                       .setDesiredPosition(position)
-                                       .vBuild();
+            rejectedCommand =
+                    AddColumn.newBuilder()
+                             .setBoard(board())
+                             .setColumn(ColumnId.generate())
+                             .setName(name)
+                             .setDesiredPosition(position)
+                             .vBuild();
 
             context().receivesCommand(successfulCommand);
             context().receivesCommand(rejectedCommand);
@@ -116,18 +116,16 @@ class BoardTest extends KanbanContextTest {
         @Test
         @DisplayName("by rejecting the addition of the column with a duplicate name")
         void rejection() {
-            EventSubject assertRejections =
-                    context().assertEvents()
-                             .withType(ColumnNameAlreadyTaken.class);
+            EventSubject assertRejections = assertEvents(ColumnNameAlreadyTaken.class);
             assertRejections.hasSize(1);
 
             ColumnNameAlreadyTaken expected =
-                    ColumnNameAlreadyTaken
-                            .newBuilder()
-                            .setColumn(rejectedCommand.getColumn())
-                            .setName(rejectedCommand.getName())
-                            .build();
-            assertRejections.message(0).isEqualTo(expected);
+                    ColumnNameAlreadyTaken.newBuilder()
+                                          .setColumn(rejectedCommand.getColumn())
+                                          .setName(rejectedCommand.getName())
+                                          .build();
+            assertRejections.message(0)
+                            .isEqualTo(expected);
         }
     }
 

--- a/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/DefaultColumnsTest.java
@@ -31,6 +31,7 @@ import io.spine.examples.kanban.BoardId;
 import io.spine.examples.kanban.ColumnPosition;
 import io.spine.examples.kanban.command.AddColumn;
 import io.spine.examples.kanban.server.board.given.AddColumnCommands;
+import io.spine.examples.kanban.server.given.ColumnPositions;
 import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,6 @@ import org.junit.jupiter.api.Test;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.examples.kanban.BoardInit.DefaultColumn;
-import static io.spine.examples.kanban.server.KanbanTest.columnPosition;
 
 @DisplayName("`DefaultColumns` should")
 class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
@@ -80,10 +80,10 @@ class DefaultColumnsTest extends UtilityClassTest<DefaultColumns> {
      * for comparison with an actual output of the mentioned method.
      */
     private static ImmutableList<AddColumn> expectedAdditionCommands(BoardId board) {
-        AddColumn toDo = additionCommand(board, "To Do", columnPosition(1, 4));
-        AddColumn inProgress = additionCommand(board, "In Progress", columnPosition(2, 4));
-        AddColumn review = additionCommand(board, "Review", columnPosition(3, 4));
-        AddColumn done = additionCommand(board, "Done", columnPosition(4, 4));
+        AddColumn toDo = additionCommand(board, "To Do", ColumnPositions.of(1, 4));
+        AddColumn inProgress = additionCommand(board, "In Progress", ColumnPositions.of(2, 4));
+        AddColumn review = additionCommand(board, "Review", ColumnPositions.of(3, 4));
+        AddColumn done = additionCommand(board, "Done", ColumnPositions.of(4, 4));
 
         return ImmutableList.of(toDo, inProgress, review, done);
     }

--- a/server/src/test/java/io/spine/examples/kanban/server/board/given/package-info.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/given/package-info.java
@@ -33,5 +33,4 @@
 package io.spine.examples.kanban.server.board.given;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/java/io/spine/examples/kanban/server/board/given/package-info.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/board/given/package-info.java
@@ -25,7 +25,8 @@
  */
 
 /**
- * Test environment classes for testing the {@link io.spine.examples.kanban.server} package.
+ * Test environment classes for testing the
+ * {@link io.spine.examples.kanban.server.board} package.
  */
 
 @CheckReturnValue

--- a/server/src/test/java/io/spine/examples/kanban/server/card/CardTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/card/CardTest.java
@@ -58,23 +58,19 @@ class CardTest extends KanbanContextTest {
             context().receivesCommand(createCard());
         }
 
-
         @Test
         @DisplayName("generating `CardCreated` event")
         void event() {
-            EventSubject assertEvents =
-                    context().assertEvents()
-                             .withType(CardCreated.class);
+            EventSubject assertEvents = assertEvents(CardCreated.class);
             assertEvents.hasSize(1);
-            CardCreated expected = CardCreated
-                    .newBuilder()
-                    .setBoard(board())
-                    .setCard(card())
-                    // We call `buildPartial()` instead of `vBuild()` to be able to omit
-                    // the `name` and `description` fields that are `required` in the event.
-                    .buildPartial();
+
+            CardCreated expected =
+                    CardCreated.newBuilder()
+                               .setBoard(board())
+                               .setCard(card())
+                               .buildPartial();
             assertEvents.message(0)
-                        .ignoringFields(3 /* name */, 4 /* description */)
+                        .comparingExpectedFieldsOnly()
                         .isEqualTo(expected);
         }
 

--- a/server/src/test/java/io/spine/examples/kanban/server/card/CardTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/card/CardTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Card logic should")
+@DisplayName("`Card` should")
 class CardTest extends KanbanContextTest {
 
     /**
@@ -50,7 +50,7 @@ class CardTest extends KanbanContextTest {
      * Verifies that a command to create a card generates corresponding event.
      */
     @Nested
-    @DisplayName("create new card")
+    @DisplayName("create a card")
     class Creation {
 
         @BeforeEach
@@ -59,7 +59,7 @@ class CardTest extends KanbanContextTest {
         }
 
         @Test
-        @DisplayName("generating `CardCreated` event")
+        @DisplayName("emitting the `CardCreated` event")
         void event() {
             EventSubject assertEvents = assertEvents(CardCreated.class);
             assertEvents.hasSize(1);

--- a/server/src/test/java/io/spine/examples/kanban/server/card/CardTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/card/CardTest.java
@@ -59,6 +59,13 @@ class CardTest extends KanbanContextTest {
         }
 
         @Test
+        @DisplayName("as entity with the `Card` state")
+        void entity() {
+            context().assertEntityWithState(card(), Card.class)
+                     .exists();
+        }
+
+        @Test
         @DisplayName("emitting the `CardCreated` event")
         void event() {
             EventSubject assertEvents = assertEvents(CardCreated.class);
@@ -72,13 +79,6 @@ class CardTest extends KanbanContextTest {
             assertEvents.message(0)
                         .comparingExpectedFieldsOnly()
                         .isEqualTo(expected);
-        }
-
-        @Test
-        @DisplayName("as entity with the `Card` state")
-        void entity() {
-            context().assertEntityWithState(card(), Card.class)
-                     .exists();
         }
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/column/ColumnAdditionProcessTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/column/ColumnAdditionProcessTest.java
@@ -48,20 +48,19 @@ class ColumnAdditionProcessTest extends KanbanContextTest {
         context().assertEntityWithState(column(), Column.class)
                  .exists();
     }
+
     @Test
     @DisplayName("emit the `ColumnAdded` event when terminated")
     void event() {
-        EventSubject assertEvents = context().assertEvents()
-                                             .withType(ColumnAdded.class);
+        EventSubject assertEvents = assertEvents(ColumnAdded.class);
         assertEvents.hasSize(1);
 
-        ColumnAdded expected = ColumnAdded
-                .newBuilder()
-                .setBoard(board())
-                .setColumn(column())
-                .setPosition(defaultPosition())
-                // We call `buildPartial()` instead of `vBuild()` to omit `required` fields.
-                .buildPartial();
+        ColumnAdded expected =
+                ColumnAdded.newBuilder()
+                           .setBoard(board())
+                           .setColumn(column())
+                           .setPosition(defaultPosition())
+                           .buildPartial();
         assertEvents.message(0)
                     .comparingExpectedFieldsOnly()
                     .isEqualTo(expected);

--- a/server/src/test/java/io/spine/examples/kanban/server/column/ColumnAdditionProcessTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/column/ColumnAdditionProcessTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 class ColumnAdditionProcessTest extends KanbanContextTest {
 
     @BeforeEach
-    void setup() {
+    void setupColumn() {
         context().receivesCommand(addColumn());
     }
 

--- a/server/src/test/java/io/spine/examples/kanban/server/column/ColumnTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/column/ColumnTest.java
@@ -37,6 +37,7 @@ import io.spine.examples.kanban.event.WipLimitSet;
 import io.spine.examples.kanban.rejection.Rejections.WipLimitAlreadySet;
 import io.spine.examples.kanban.rejection.Rejections.WipLimitExceeded;
 import io.spine.examples.kanban.server.KanbanContextTest;
+import io.spine.examples.kanban.server.given.WipLimits;
 import io.spine.testing.server.EventSubject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -71,7 +72,7 @@ class ColumnTest extends KanbanContextTest {
             WipLimitSet expected = WipLimitSet
                     .newBuilder()
                     .setColumn(column())
-                    .setLimit(wipLimit(limit))
+                    .setLimit(WipLimits.of(limit))
                     .vBuild();
             assertEvents.message(0)
                         .isEqualTo(expected);
@@ -95,8 +96,8 @@ class ColumnTest extends KanbanContextTest {
             WipLimitChanged expected = WipLimitChanged
                     .newBuilder()
                     .setColumn(column)
-                    .setPreviousValue(wipLimit(initialLimit))
-                    .setNewValue(wipLimit(updatedLimit))
+                    .setPreviousValue(WipLimits.of(initialLimit))
+                    .setNewValue(WipLimits.of(updatedLimit))
                     .vBuild();
             assertEvents.message(0)
                         .isEqualTo(expected);
@@ -118,7 +119,7 @@ class ColumnTest extends KanbanContextTest {
             WipLimitRemoved expected = WipLimitRemoved
                     .newBuilder()
                     .setColumn(column)
-                    .setPreviousLimit(wipLimit(initialLimit))
+                    .setPreviousLimit(WipLimits.of(initialLimit))
                     .vBuild();
             assertEvents.message(0)
                         .isEqualTo(expected);
@@ -140,7 +141,7 @@ class ColumnTest extends KanbanContextTest {
             WipLimitAlreadySet expected = WipLimitAlreadySet
                     .newBuilder()
                     .setColumn(column)
-                    .setLimit(wipLimit(limit))
+                    .setLimit(WipLimits.of(limit))
                     .vBuild();
             assertEvents.message(0)
                         .isEqualTo(expected);
@@ -196,7 +197,7 @@ class ColumnTest extends KanbanContextTest {
                     .newBuilder()
                     .setColumn(columnWithLimit)
                     .setCard(cardToBeRejected)
-                    .setLimit(wipLimit(LIMIT))
+                    .setLimit(WipLimits.of(LIMIT))
                     .vBuild();
             assertRejections.message(0)
                             .isEqualTo(expectedRejection);

--- a/server/src/test/java/io/spine/examples/kanban/server/column/ColumnTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/column/ColumnTest.java
@@ -141,7 +141,7 @@ class ColumnTest extends KanbanContextTest {
         private ColumnId columnWithLimit;
 
         @BeforeEach
-        void initColumn() {
+        void setupColumnWithLimit() {
             columnWithLimit = ColumnId.generate();
             context().receivesCommand(addColumn(columnWithLimit))
                      .receivesCommand(setWipLimit(columnWithLimit, limit));

--- a/server/src/test/java/io/spine/examples/kanban/server/column/ColumnTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/column/ColumnTest.java
@@ -64,16 +64,14 @@ class ColumnTest extends KanbanContextTest {
             int limit = 3;
             context().receivesCommand(setWipLimit(column(), limit));
 
-            EventSubject assertEvents =
-                    context().assertEvents()
-                             .withType(WipLimitSet.class);
-
+            EventSubject assertEvents = assertEvents(WipLimitSet.class);
             assertEvents.hasSize(1);
-            WipLimitSet expected = WipLimitSet
-                    .newBuilder()
-                    .setColumn(column())
-                    .setLimit(WipLimits.of(limit))
-                    .vBuild();
+
+            WipLimitSet expected =
+                    WipLimitSet.newBuilder()
+                               .setColumn(column())
+                               .setLimit(WipLimits.of(limit))
+                               .vBuild();
             assertEvents.message(0)
                         .isEqualTo(expected);
         }
@@ -88,17 +86,15 @@ class ColumnTest extends KanbanContextTest {
             context().receivesCommand(setWipLimit(column, initialLimit))
                      .receivesCommand(setWipLimit(column, updatedLimit));
 
-            EventSubject assertEvents =
-                    context().assertEvents()
-                             .withType(WipLimitChanged.class);
-
+            EventSubject assertEvents = assertEvents(WipLimitChanged.class);
             assertEvents.hasSize(1);
-            WipLimitChanged expected = WipLimitChanged
-                    .newBuilder()
-                    .setColumn(column)
-                    .setPreviousValue(WipLimits.of(initialLimit))
-                    .setNewValue(WipLimits.of(updatedLimit))
-                    .vBuild();
+
+            WipLimitChanged expected =
+                    WipLimitChanged.newBuilder()
+                                   .setColumn(column)
+                                   .setPreviousValue(WipLimits.of(initialLimit))
+                                   .setNewValue(WipLimits.of(updatedLimit))
+                                   .vBuild();
             assertEvents.message(0)
                         .isEqualTo(expected);
         }
@@ -111,16 +107,14 @@ class ColumnTest extends KanbanContextTest {
             context().receivesCommand(setWipLimit(column, initialLimit))
                      .receivesCommand(setWipLimit(column, 0));
 
-            EventSubject assertEvents =
-                    context().assertEvents()
-                             .withType(WipLimitRemoved.class);
-
+            EventSubject assertEvents = assertEvents(WipLimitRemoved.class);
             assertEvents.hasSize(1);
-            WipLimitRemoved expected = WipLimitRemoved
-                    .newBuilder()
-                    .setColumn(column)
-                    .setPreviousLimit(WipLimits.of(initialLimit))
-                    .vBuild();
+
+            WipLimitRemoved expected =
+                    WipLimitRemoved.newBuilder()
+                                   .setColumn(column)
+                                   .setPreviousLimit(WipLimits.of(initialLimit))
+                                   .vBuild();
             assertEvents.message(0)
                         .isEqualTo(expected);
         }
@@ -133,16 +127,14 @@ class ColumnTest extends KanbanContextTest {
             context().receivesCommand(setWipLimit(column, limit))
                      .receivesCommand(setWipLimit(column, limit));
 
-            EventSubject assertEvents =
-                    context().assertEvents()
-                             .withType(WipLimitAlreadySet.class);
-
+            EventSubject assertEvents = assertEvents(WipLimitAlreadySet.class);
             assertEvents.hasSize(1);
-            WipLimitAlreadySet expected = WipLimitAlreadySet
-                    .newBuilder()
-                    .setColumn(column)
-                    .setLimit(WipLimits.of(limit))
-                    .vBuild();
+
+            WipLimitAlreadySet expected =
+                    WipLimitAlreadySet.newBuilder()
+                                      .setColumn(column)
+                                      .setLimit(WipLimits.of(limit))
+                                      .vBuild();
             assertEvents.message(0)
                         .isEqualTo(expected);
         }
@@ -188,19 +180,19 @@ class ColumnTest extends KanbanContextTest {
         @DisplayName("prohibit adding a card when the limit reached")
         void rejection() {
             fillUpToTheLimit();
-            CardId cardToBeRejected = addCard();
-            EventSubject assertRejections =
-                    context().assertEvents()
-                             .withType(WipLimitExceeded.class);
+            CardId rejectedCard = addCard();
+
+            EventSubject assertRejections = assertEvents(WipLimitExceeded.class);
             assertRejections.hasSize(1);
-            WipLimitExceeded expectedRejection = WipLimitExceeded
-                    .newBuilder()
-                    .setColumn(columnWithLimit)
-                    .setCard(cardToBeRejected)
-                    .setLimit(WipLimits.of(LIMIT))
-                    .vBuild();
+
+            WipLimitExceeded expected =
+                    WipLimitExceeded.newBuilder()
+                                    .setColumn(columnWithLimit)
+                                    .setCard(rejectedCard)
+                                    .setLimit(WipLimits.of(LIMIT))
+                                    .vBuild();
             assertRejections.message(0)
-                            .isEqualTo(expectedRejection);
+                            .isEqualTo(expected);
         }
 
         private AddCardToColumn addCardToColumn(CardId card) {

--- a/server/src/test/java/io/spine/examples/kanban/server/column/ColumnTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/column/ColumnTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.spine.testing.Tests.repeat;
 
-@DisplayName("Column logic should")
+@DisplayName("`Column` should")
 class ColumnTest extends KanbanContextTest {
 
     @BeforeEach
@@ -56,7 +56,6 @@ class ColumnTest extends KanbanContextTest {
     }
 
     @Nested
-    @DisplayName("support WIP limit")
     class SettingWipLimit {
         private final WipLimit limit = WipLimits.of(5);
 
@@ -66,7 +65,7 @@ class ColumnTest extends KanbanContextTest {
         }
 
         @Test
-        @DisplayName("setting non-zero value to previously unlimited column")
+        @DisplayName("set a non-zero WIP limit to previously unlimited column")
         void setLimit() {
             EventSubject assertEvents = assertEvents(WipLimitSet.class);
             assertEvents.hasSize(1);
@@ -81,7 +80,7 @@ class ColumnTest extends KanbanContextTest {
         }
 
         @Test
-        @DisplayName("changing limit value")
+        @DisplayName("change the WIP limit")
         void changeLimit() {
             WipLimit newLimit = WipLimits.of(6);
             context().receivesCommand(setWipLimit(column(), newLimit));
@@ -100,7 +99,7 @@ class ColumnTest extends KanbanContextTest {
         }
 
         @Test
-        @DisplayName("clearing limit value")
+        @DisplayName("remove the WIP limit")
         void clearLimit() {
             context().receivesCommand(setWipLimit(column(), WipLimits.of(0)));
 
@@ -117,7 +116,7 @@ class ColumnTest extends KanbanContextTest {
         }
 
         @Test
-        @DisplayName("not allowing the same value")
+        @DisplayName("reject setting the WIP limit to the same value")
         void rejectSameValue() {
             context().receivesCommand(setWipLimit(column(), limit));
 
@@ -135,7 +134,7 @@ class ColumnTest extends KanbanContextTest {
     }
 
     @Nested
-    @DisplayName("protect WIP limit")
+    @DisplayName("guard the WIP limit by")
     class GuardingWipLimit {
 
         private final WipLimit limit = WipLimits.of(5);
@@ -171,7 +170,7 @@ class ColumnTest extends KanbanContextTest {
         }
 
         @Test
-        @DisplayName("prohibit adding a card when the limit reached")
+        @DisplayName("rejecting card addition when the limit reached")
         void rejection() {
             fillUpToTheLimit();
             CardId rejectedCard = addCard();

--- a/server/src/test/java/io/spine/examples/kanban/server/given/ColumnPositions.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/given/ColumnPositions.java
@@ -31,7 +31,7 @@ import io.spine.examples.kanban.ColumnPosition;
 /**
  * Provides utility methods for {@link ColumnPosition} for testing purposes.
  */
-public class ColumnPositions {
+public final class ColumnPositions {
 
     /**
      * Prevents utility class instantiation.

--- a/server/src/test/java/io/spine/examples/kanban/server/given/ColumnPositions.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/given/ColumnPositions.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.kanban.server.given;
+
+import io.spine.examples.kanban.ColumnPosition;
+
+/**
+ * Provides utility methods for {@link ColumnPosition} for testing purposes.
+ */
+public class ColumnPositions {
+
+    /**
+     * Prevents utility class instantiation.
+     */
+    private ColumnPositions() {
+    }
+
+    /**
+     * Creates a column position with the passed index and total number of columns.
+     */
+    public static ColumnPosition of(int index, int ofTotal) {
+        return ColumnPosition
+                .newBuilder()
+                .setIndex(index)
+                .setOfTotal(ofTotal)
+                .vBuild();
+    }
+}

--- a/server/src/test/java/io/spine/examples/kanban/server/given/TestCommands.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/given/TestCommands.java
@@ -24,13 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.kanban.server;
+package io.spine.examples.kanban.server.given;
 
 import io.spine.examples.kanban.BoardId;
 import io.spine.examples.kanban.CardId;
 import io.spine.examples.kanban.ColumnId;
 import io.spine.examples.kanban.ColumnPosition;
-import io.spine.examples.kanban.WipLimit;
 import io.spine.examples.kanban.command.AddColumn;
 import io.spine.examples.kanban.command.CreateBoard;
 import io.spine.examples.kanban.command.CreateCard;
@@ -42,22 +41,28 @@ import static io.spine.testing.TestValues.randomString;
 /**
  * Static factories for test command messages.
  */
-final class TestCommands {
+public final class TestCommands {
 
-    /** Prevents instantiation. */
+    /**
+     * Prevents instantiation.
+     */
     private TestCommands() {
     }
 
-    /** Create a board with the passed ID. */
-    static CreateBoard createBoard(BoardId board) {
+    /**
+     * Create a board with the passed ID.
+     */
+    public static CreateBoard createBoard(BoardId board) {
         return CreateBoard
                 .newBuilder()
                 .setBoard(board)
                 .vBuild();
     }
 
-    /** Add the column to the board. */
-    static AddColumn addColumn(
+    /**
+     * Add the column to the board.
+     */
+    public static AddColumn addColumn(
             BoardId board,
             ColumnId column,
             ColumnPosition columnPosition
@@ -71,8 +76,10 @@ final class TestCommands {
                 .vBuild();
     }
 
-    /** Create the card on the specified board. */
-    static CreateCard createCard(BoardId board, CardId card) {
+    /**
+     * Create the card on the specified board.
+     */
+    public static CreateCard createCard(BoardId board, CardId card) {
         return CreateCard
                 .newBuilder()
                 .setCard(card)
@@ -83,12 +90,8 @@ final class TestCommands {
 
     /**
      * Set the WIP limit for the column.
-     *
-     * <p>Passing zero clears the limit.
-     *
-     * @see WipLimit
      */
-    static SetWipLimit setWipLimit(ColumnId column, int limit) {
+    public static SetWipLimit setWipLimit(ColumnId column, int limit) {
         return SetWipLimit
                 .newBuilder()
                 .setColumn(column)

--- a/server/src/test/java/io/spine/examples/kanban/server/given/TestCommands.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/given/TestCommands.java
@@ -30,6 +30,7 @@ import io.spine.examples.kanban.BoardId;
 import io.spine.examples.kanban.CardId;
 import io.spine.examples.kanban.ColumnId;
 import io.spine.examples.kanban.ColumnPosition;
+import io.spine.examples.kanban.WipLimit;
 import io.spine.examples.kanban.command.AddColumn;
 import io.spine.examples.kanban.command.CreateBoard;
 import io.spine.examples.kanban.command.CreateCard;
@@ -90,11 +91,11 @@ public final class TestCommands {
     /**
      * Set the WIP limit for the column.
      */
-    public static SetWipLimit setWipLimit(ColumnId column, int limit) {
+    public static SetWipLimit setWipLimit(ColumnId column, WipLimit limit) {
         return SetWipLimit
                 .newBuilder()
                 .setColumn(column)
-                .setLimit(WipLimits.of(limit))
+                .setLimit(limit)
                 .vBuild();
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/given/TestCommands.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/given/TestCommands.java
@@ -35,7 +35,6 @@ import io.spine.examples.kanban.command.CreateBoard;
 import io.spine.examples.kanban.command.CreateCard;
 import io.spine.examples.kanban.command.SetWipLimit;
 
-import static io.spine.examples.kanban.server.KanbanTest.wipLimit;
 import static io.spine.testing.TestValues.randomString;
 
 /**
@@ -95,7 +94,7 @@ public final class TestCommands {
         return SetWipLimit
                 .newBuilder()
                 .setColumn(column)
-                .setLimit(wipLimit(limit))
+                .setLimit(WipLimits.of(limit))
                 .vBuild();
     }
 }

--- a/server/src/test/java/io/spine/examples/kanban/server/given/TestCommands.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/given/TestCommands.java
@@ -39,18 +39,18 @@ import io.spine.examples.kanban.command.SetWipLimit;
 import static io.spine.testing.TestValues.randomString;
 
 /**
- * Static factories for test command messages.
+ * Provides factory methods for test commands.
  */
 public final class TestCommands {
 
     /**
-     * Prevents instantiation.
+     * Prevents utility class instantiation.
      */
     private TestCommands() {
     }
 
     /**
-     * Create a board with the passed ID.
+     * Creates the {@link CreateBoard} command with the provided board ID.
      */
     public static CreateBoard createBoard(BoardId board) {
         return CreateBoard
@@ -60,7 +60,8 @@ public final class TestCommands {
     }
 
     /**
-     * Add the column to the board.
+     * Creates the {@link AddColumn} command with the provided board ID,
+     * column ID, position and a generated column name.
      */
     public static AddColumn addColumn(
             BoardId board,
@@ -71,25 +72,27 @@ public final class TestCommands {
                 .newBuilder()
                 .setBoard(board)
                 .setColumn(column)
-                .setName("Generated column" + randomString())
+                .setName(randomString())
                 .setDesiredPosition(columnPosition)
                 .vBuild();
     }
 
     /**
-     * Create the card on the specified board.
+     * Creates the {@link CreateCard} command with the provided board ID,
+     * card ID and a generated card name.
      */
     public static CreateCard createCard(BoardId board, CardId card) {
         return CreateCard
                 .newBuilder()
                 .setCard(card)
                 .setBoard(board)
-                .setName("Generated card " + randomString())
+                .setName(randomString())
                 .vBuild();
     }
 
     /**
-     * Set the WIP limit for the column.
+     * Creates the {@link SetWipLimit} command with the provided column ID
+     * and WIP limit.
      */
     public static SetWipLimit setWipLimit(ColumnId column, WipLimit limit) {
         return SetWipLimit

--- a/server/src/test/java/io/spine/examples/kanban/server/given/WipLimits.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/given/WipLimits.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.kanban.server.given;
+
+import io.spine.examples.kanban.WipLimit;
+
+/**
+ * Provides utility methods for {@link WipLimit} for testing purposes.
+ */
+public class WipLimits {
+
+    /**
+     * Prevents utility class instantiation.
+     */
+    private WipLimits() {
+    }
+
+    /**
+     * Creates a limit instance with the passed value.
+     */
+    public static WipLimit of(int value) {
+        return WipLimit
+                .newBuilder()
+                .setValue(value)
+                .vBuild();
+    }
+}

--- a/server/src/test/java/io/spine/examples/kanban/server/given/WipLimits.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/given/WipLimits.java
@@ -31,7 +31,7 @@ import io.spine.examples.kanban.WipLimit;
 /**
  * Provides utility methods for {@link WipLimit} for testing purposes.
  */
-public class WipLimits {
+public final class WipLimits {
 
     /**
      * Prevents utility class instantiation.

--- a/server/src/test/java/io/spine/examples/kanban/server/given/package-info.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/given/package-info.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Test environment classes for testing the
+ * {@link io.spine.examples.kanban.server} package.
+ */
+
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.examples.kanban.server.given;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
@@ -53,7 +53,7 @@ class BoardProjectionTest extends KanbanContextTest {
     private ProtoSubject entityState;
 
     @BeforeEach
-    void initBoard() {
+    void setupBoard() {
         context().receivesCommand(createBoard());
         columns = receivedCommands(AddColumn.class)
                 .map(AddColumn::getColumn)
@@ -66,7 +66,7 @@ class BoardProjectionTest extends KanbanContextTest {
 
     @Test
     @DisplayName("have the state with the ID of the board")
-    void id() {
+    void entity() {
         BoardView expected =
                 BoardView.newBuilder()
                          .setId(board())

--- a/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
@@ -67,6 +67,15 @@ class BoardProjectionTest extends KanbanContextTest {
         entityState = assertState();
     }
 
+    private <T extends CommandMessage> Stream<T> commands(Class<T> commandClass) {
+        return context()
+                .assertCommands()
+                .withType(commandClass)
+                .actual()
+                .stream()
+                .map(c -> unpack(c.getMessage(), commandClass));
+    }
+
     @Test
     @DisplayName("have the state with the ID of the board")
     void id() {

--- a/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
@@ -45,8 +45,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
 import static io.spine.protobuf.AnyPacker.unpack;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @DisplayName("BoardProjection should")
 class BoardProjectionTest extends KanbanContextTest {
@@ -87,7 +87,7 @@ class BoardProjectionTest extends KanbanContextTest {
                                        .build())
                        .collect(toImmutableList());
 
-        assertFalse(expectedColumns.isEmpty());
+        assertThat(expectedColumns).isNotEmpty();
 
         BoardView expected = BoardView
                 .newBuilder()

--- a/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
@@ -45,7 +45,7 @@ import java.util.List;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 
-@DisplayName("BoardProjection should")
+@DisplayName("`BoardProjection` should")
 class BoardProjectionTest extends KanbanContextTest {
 
     private ImmutableList<ColumnId> columns;

--- a/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
+++ b/server/src/test/java/io/spine/examples/kanban/server/view/BoardProjectionTest.java
@@ -64,6 +64,11 @@ class BoardProjectionTest extends KanbanContextTest {
         entityState = assertState();
     }
 
+    private ProtoSubject assertState() {
+        return context().assertEntity(board(), BoardProjection.class)
+                        .hasStateThat();
+    }
+
     @Test
     @DisplayName("have the state with the ID of the board")
     void entity() {
@@ -115,10 +120,5 @@ class BoardProjectionTest extends KanbanContextTest {
 
         entityState.comparingExpectedFieldsOnly()
                    .isEqualTo(expected);
-    }
-
-    private ProtoSubject assertState() {
-        return context().assertEntity(board(), BoardProjection.class)
-                        .hasStateThat();
     }
 }


### PR DESCRIPTION
The goal of the PR is to make `server` tests cleaner and appear as if "one" human wrote them.

Changes focus on reducing duplication and making code consistent in multiple directions: indentation, spacing, and naming. Also, this PR fixes and makes consistent display names for tests. 