### PR TITLE
Add board routing

### DIFF
--- a/web/client-js/src/components/board/AddColumnForm.vue
+++ b/web/client-js/src/components/board/AddColumnForm.vue
@@ -37,7 +37,7 @@ import { createNamespacedHelpers } from "vuex";
 import Board from "@/store/board";
 import { defineComponent } from "vue";
 import { ActionType } from "@/store/board/actions";
-import { AddColumnActionPayload } from "@/store/board/actions/add-column-action";
+import { AddColumnActionPayload } from "@/store/board/actions/command/add-column-action";
 
 const { mapActions } = createNamespacedHelpers(Board.MODULE_NAME);
 
@@ -53,7 +53,7 @@ export default defineComponent({
   },
   methods: {
     ...mapActions({
-      addColumn: ActionType.ADD_COLUMN,
+      addColumn: ActionType.Command.ADD_COLUMN,
     }),
     submit() {
       if (this.name.length > 0) {

--- a/web/client-js/src/router/index.ts
+++ b/web/client-js/src/router/index.ts
@@ -26,12 +26,24 @@
 
 import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
 import BoardView from "@/views/BoardView.vue";
+import CreateBoardView from "@/views/CreateBoardView.vue";
 
 const routes: Array<RouteRecordRaw> = [
   {
-    path: "/",
+    path: "/boards/:id",
     name: "board",
     component: BoardView,
+  },
+  {
+    path: "/boards/create",
+    name: "create-board",
+    component: CreateBoardView,
+  },
+  {
+    path: "/",
+    redirect: {
+      name: "create-board",
+    },
   },
 ];
 

--- a/web/client-js/src/store/board/actions/command/add-column-action.ts
+++ b/web/client-js/src/store/board/actions/command/add-column-action.ts
@@ -114,17 +114,24 @@ export default class AddColumnAction extends BoardAction<
       .then(({ eventEmitted, unsubscribe }) => {
         eventEmitted.subscribe((e: Event) => {
           unsubscribe();
-          const rejection: ColumnNameAlreadyTaken = AnyPacker.unpack(
-            e.getMessage()
-          ).as(
-            Type.forClass(proto.spine_examples.kanban.ColumnNameAlreadyTaken)
-          );
+          const rejection: ColumnNameAlreadyTaken =
+            this.unpackColumnNameAlreadyTaken(e);
           const error = ErrorNotification.of(
             `The name "${rejection.getName()}" is already taken`
           );
           addNotification(this.getActionContext(), error);
         });
       });
+  }
+
+  /**
+   * Unpacks the {@link ColumnNameAlreadyTaken} event from the {@link Event}.
+   * @private
+   */
+  private unpackColumnNameAlreadyTaken(e: Event) {
+    return AnyPacker.unpack(e.getMessage()).as(
+      Type.forClass(proto.spine_examples.kanban.ColumnNameAlreadyTaken)
+    );
   }
 
   /**

--- a/web/client-js/src/store/board/actions/command/add-column-action.ts
+++ b/web/client-js/src/store/board/actions/command/add-column-action.ts
@@ -125,10 +125,10 @@ export default class AddColumnAction extends BoardAction<
   }
 
   /**
-   * Unpacks the {@link ColumnNameAlreadyTaken} event from the {@link Event}.
+   * Unpacks the {@link ColumnNameAlreadyTaken} rejection from the {@link Event}.
    * @private
    */
-  private unpackColumnNameAlreadyTaken(e: Event) {
+  private unpackColumnNameAlreadyTaken(e: Event): ColumnNameAlreadyTaken {
     return AnyPacker.unpack(e.getMessage()).as(
       Type.forClass(proto.spine_examples.kanban.ColumnNameAlreadyTaken)
     );

--- a/web/client-js/src/store/board/actions/command/add-column-action.ts
+++ b/web/client-js/src/store/board/actions/command/add-column-action.ts
@@ -62,8 +62,8 @@ export default class AddColumnAction extends BoardAction<
   /**
    * Sends the command to add a column.
    *
-   * It is assumed that the subscription to {@link ColumnAdded} events
-   * already exists after {@linkplain CreateBoardAction board creation}.
+   * It is assumed that the {@linkplain SubscribeToColumnAddedAction subscription} to
+   * {@link ColumnAdded} events already exists.
    * @protected
    */
   protected execute(): void {

--- a/web/client-js/src/store/board/actions/command/create-board-action.ts
+++ b/web/client-js/src/store/board/actions/command/create-board-action.ts
@@ -89,7 +89,7 @@ export default class CreateBoardAction extends BoardAction<null, void> {
           const innerEvent: BoardCreated = this.unpackBoardCreated(e);
           const board = this.extractBoard(innerEvent);
           this.addBoardToState(board);
-          CreateBoardAction.redirectToBoard(board);
+          CreateBoardAction.redirectToBoard(board.getId()!);
         });
       });
   }
@@ -126,10 +126,10 @@ export default class CreateBoardAction extends BoardAction<null, void> {
    * Redirects to the view of the board with the provided ID.
    * @private
    */
-  private static redirectToBoard(b: Board): void {
+  private static redirectToBoard(b: BoardId): void {
     router.push({
       name: "board",
-      params: { id: b.getId()!.getUuid() },
+      params: { id: b.getUuid() },
     });
   }
 

--- a/web/client-js/src/store/board/actions/command/create-board-action.ts
+++ b/web/client-js/src/store/board/actions/command/create-board-action.ts
@@ -114,10 +114,18 @@ export default class CreateBoardAction extends BoardAction<null, void> {
     return board;
   }
 
+  /**
+   * Commits the mutation to add the provided {@link Board} to the state.
+   * @private
+   */
   private addBoardToState(b: Board): void {
     this.getActionContext().commit(MutationType.SET_BOARD, b);
   }
 
+  /**
+   * Redirects to the view of the board with the provided ID.
+   * @private
+   */
   private static redirectToBoard(b: Board): void {
     router.push({
       name: "board",

--- a/web/client-js/src/store/board/actions/command/create-board-action.ts
+++ b/web/client-js/src/store/board/actions/command/create-board-action.ts
@@ -98,7 +98,7 @@ export default class CreateBoardAction extends BoardAction<null, void> {
    * Unpacks the {@link BoardCreated} event from the {@link Event}.
    * @private
    */
-  private unpackBoardCreated(e: Event) {
+  private unpackBoardCreated(e: Event): BoardCreated {
     return AnyPacker.unpack(e.getMessage()).as(
       Type.forClass(proto.spine_examples.kanban.BoardCreated)
     );

--- a/web/client-js/src/store/board/actions/command/create-board-action.ts
+++ b/web/client-js/src/store/board/actions/command/create-board-action.ts
@@ -41,7 +41,7 @@ import { Filters } from "spine-web";
 import { ActionContext, ActionHandler } from "vuex";
 import { RootState } from "@/store/root/root-state";
 import { BoardState } from "@/store/board/state/board-state";
-import { ActionType } from "@/store/board/actions";
+import router from "@/router";
 
 type CreateBoard = proto.spine_examples.kanban.CreateBoard;
 
@@ -88,8 +88,8 @@ export default class CreateBoardAction extends BoardAction<null, void> {
           unsubscribe();
           const innerEvent: BoardCreated = this.unpackBoardCreated(e);
           const board = this.extractBoard(innerEvent);
-          this.subscribeToColumnAdded(board);
           this.addBoardToState(board);
+          CreateBoardAction.redirectToBoard(board);
         });
       });
   }
@@ -114,20 +114,15 @@ export default class CreateBoardAction extends BoardAction<null, void> {
     return board;
   }
 
-  /**
-   * Dispatches action to subscribe for {@link ColumnAdded} produced by
-   * the board with the provided ID.
-   * @private
-   */
-  private subscribeToColumnAdded(b: Board): void {
-    this.getActionContext().dispatch(
-      ActionType.Subscription.SUBSCRIBE_TO_COLUMN_ADDED,
-      b.getId()
-    );
-  }
-
   private addBoardToState(b: Board): void {
     this.getActionContext().commit(MutationType.SET_BOARD, b);
+  }
+
+  private static redirectToBoard(b: Board): void {
+    router.push({
+      name: "board",
+      params: { id: b.getId()!.getUuid() },
+    });
   }
 
   /**

--- a/web/client-js/src/store/board/actions/index.ts
+++ b/web/client-js/src/store/board/actions/index.ts
@@ -27,29 +27,47 @@
 import { ActionTree } from "vuex";
 import { BoardState } from "@/store/board/state/board-state";
 import { RootState } from "@/store/root/root-state";
-import CreateBoardAction from "@/store/board/actions/create-board-action";
-import AddColumnAction from "@/store/board/actions/add-column-action";
+import CreateBoardAction from "@/store/board/actions/command/create-board-action";
+import AddColumnAction from "@/store/board/actions/command/add-column-action";
+import FetchBoardAction from "@/store/board/actions/query/fetch-board-action";
+import SubscribeToColumnAddedAction from "@/store/board/actions/subscription/subscribe-to-column-added-action";
 
 /**
  * Defines action types to interact with the remote board state.
  */
 export const ActionType = {
-  /**
-   * Subscribes to the {@link BoardCreated} and {@link ColumnAdded} events and sends
-   * the `proto.spine_examples.kanban.CreateBoard` command to create a board.
-   */
-  CREATE_BOARD: "createBoard",
+  Query: {
+    /**
+     * Fetches the {@link Board} with the provided ID from the server.
+     */
+    FETCH_BOARD: "fetchBoard",
+  },
+  Command: {
+    /**
+     * Creates a board.
+     */
+    CREATE_BOARD: "createBoard",
 
-  /**
-   * Sends the `proto.spine_examples.kanban.AddColumn` command to add the column.
-   */
-  ADD_COLUMN: "addColumn",
+    /**
+     * Adds a column.
+     */
+    ADD_COLUMN: "addColumn",
+  },
+  Subscription: {
+    /**
+     * Subscribes to {@link ColumnAdded} events produced by the provided board.
+     */
+    SUBSCRIBE_TO_COLUMN_ADDED: "subscribeToColumnAdded",
+  },
 };
 
 /**
  * Exposes actions to interact with the remote board state.
  */
 export const actions: ActionTree<BoardState, RootState> = {
-  [ActionType.CREATE_BOARD]: CreateBoardAction.newHandler(),
-  [ActionType.ADD_COLUMN]: AddColumnAction.newHandler(),
+  [ActionType.Query.FETCH_BOARD]: FetchBoardAction.newHandler(),
+  [ActionType.Command.CREATE_BOARD]: CreateBoardAction.newHandler(),
+  [ActionType.Command.ADD_COLUMN]: AddColumnAction.newHandler(),
+  [ActionType.Subscription.SUBSCRIBE_TO_COLUMN_ADDED]:
+    SubscribeToColumnAddedAction.newHandler(),
 };

--- a/web/client-js/src/store/board/actions/index.ts
+++ b/web/client-js/src/store/board/actions/index.ts
@@ -38,7 +38,7 @@ import SubscribeToColumnAddedAction from "@/store/board/actions/subscription/sub
 export const ActionType = {
   Query: {
     /**
-     * Fetches the {@link Board} with the provided ID from the server.
+     * Fetches the {@link Board} with the provided ID.
      */
     FETCH_BOARD: "fetchBoard",
   },

--- a/web/client-js/src/store/board/actions/query/fetch-board-action.ts
+++ b/web/client-js/src/store/board/actions/query/fetch-board-action.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { BoardAction } from "@/store/board/actions/base/board-action";
+import { client } from "@/dependency/container";
+import { Board, BoardId } from "@/store/board/aliases";
+import { MutationType } from "@/store/board/mutations";
+import { ActionContext, ActionHandler } from "vuex";
+import { BoardState } from "@/store/board/state/board-state";
+import { RootState } from "@/store/root/root-state";
+
+/**
+ * Fetches the {@link Board} with the provided ID from the server.
+ */
+export default class FetchBoardAction extends BoardAction<BoardId, Board> {
+  /**
+   * Sends a query to retrieve the {@link Board} with the provided ID.
+   *
+   * If the board with the provided ID exists, it is added to the local state.
+   * @protected
+   */
+  protected execute(): Board {
+    return client
+      .select(proto.spine_examples.kanban.BoardView)
+      .byId(this.boardId())
+      .run()
+      .then((boards: Array<Board>) => {
+        if (boards.length > 0) {
+          const board = boards[0];
+          this.addBoardToState(board);
+          return board;
+        }
+      });
+  }
+
+  /**
+   * Retrieves the {@link BoardId} from the action payload.
+   * @private
+   */
+  private boardId(): BoardId {
+    return this.getPayload()!;
+  }
+
+  /**
+   * Commits the mutation to add the provided {@link Board} to the state.
+   * @private
+   */
+  private addBoardToState(b: Board): void {
+    this.getActionContext().commit(MutationType.SET_BOARD, b);
+  }
+
+  /**
+   * Creates the {@link ActionHandler} to be used by the store.
+   */
+  public static newHandler(): ActionHandler<BoardState, RootState> {
+    return (ctx: ActionContext<BoardState, RootState>, p: BoardId): Board => {
+      return new FetchBoardAction(ctx, p).execute();
+    };
+  }
+}

--- a/web/client-js/src/store/board/actions/subscription/subscribe-to-column-added-action.ts
+++ b/web/client-js/src/store/board/actions/subscription/subscribe-to-column-added-action.ts
@@ -78,7 +78,7 @@ export default class SubscribeToColumnAddedAction extends BoardAction<
    * Unpacks the {@link ColumnAdded} event from the {@link Event}.
    * @private
    */
-  private unpackColumnAdded(e: Event) {
+  private unpackColumnAdded(e: Event): ColumnAdded {
     return AnyPacker.unpack(e.getMessage()).as(
       Type.forClass(proto.spine_examples.kanban.ColumnAdded)
     );

--- a/web/client-js/src/store/board/actions/subscription/subscribe-to-column-added-action.ts
+++ b/web/client-js/src/store/board/actions/subscription/subscribe-to-column-added-action.ts
@@ -101,8 +101,8 @@ export default class SubscribeToColumnAddedAction extends BoardAction<
    * Commits the mutation to add the provided {@link Column} to the state.
    * @private
    */
-  private addColumnToState(column: Column): void {
-    this.getActionContext().commit(MutationType.ADD_COLUMN, column);
+  private addColumnToState(c: Column): void {
+    this.getActionContext().commit(MutationType.ADD_COLUMN, c);
   }
 
   /**

--- a/web/client-js/src/store/board/actions/subscription/subscribe-to-column-added-action.ts
+++ b/web/client-js/src/store/board/actions/subscription/subscribe-to-column-added-action.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { BoardAction } from "@/store/board/actions/base/board-action";
+import { BoardId, ColumnAdded } from "@/store/board/aliases";
+import { ActionContext, ActionHandler } from "vuex";
+import { BoardState } from "@/store/board/state/board-state";
+import { RootState } from "@/store/root/root-state";
+import { client } from "@/dependency/container";
+import { Event } from "spine-web/proto/spine/core/event_pb";
+import { AnyPacker } from "spine-web/client/any-packer";
+import { Type } from "spine-web/client/typed-message";
+import { MutationType } from "@/store/board/mutations";
+import { Filters } from "spine-web";
+
+type Column = proto.spine_examples.kanban.Column;
+
+/**
+ * Subscribes to {@link ColumnAdded} events produced by the provided board.
+ */
+export default class SubscribeToColumnAddedAction extends BoardAction<
+  BoardId,
+  void
+> {
+  /**
+   * Creates a subscription for {@link ColumnAdded} events produced by the board with
+   * the provided ID.
+   *
+   * Extracts columns from arrived events and adds them to the local state.
+   * @protected
+   */
+  protected execute(): void {
+    client
+      .subscribeToEvent(proto.spine_examples.kanban.ColumnAdded)
+      .where(Filters.eq("board", this.boardId()))
+      .post()
+      .then(({ eventEmitted }) => {
+        eventEmitted.subscribe((e: Event) => {
+          const innerEvent: ColumnAdded = this.unpackColumnAdded(e);
+          const column = this.extractColumn(innerEvent);
+          this.addColumnToState(column);
+        });
+      });
+  }
+
+  /**
+   * Retrieves the {@link BoardId} from the action payload.
+   * @private
+   */
+  private boardId(): BoardId {
+    return this.getPayload()!;
+  }
+
+  /**
+   * Unpacks the {@link ColumnAdded} event from the {@link Event}.
+   * @private
+   */
+  private unpackColumnAdded(e: Event) {
+    return AnyPacker.unpack(e.getMessage()).as(
+      Type.forClass(proto.spine_examples.kanban.ColumnAdded)
+    );
+  }
+
+  /**
+   * Extracts the {@link Column} from the {@link ColumnAdded} event.
+   * @private
+   */
+  private extractColumn(e: ColumnAdded): Column {
+    const column = new proto.spine_examples.kanban.Column();
+    column.setId(e.getColumn());
+    column.setBoard(e.getBoard());
+    column.setName(e.getName());
+    column.setPosition(e.getPosition());
+    return column;
+  }
+
+  /**
+   * Commits the mutation to add the provided {@link Column} to the state.
+   * @private
+   */
+  private addColumnToState(column: Column): void {
+    this.getActionContext().commit(MutationType.ADD_COLUMN, column);
+  }
+
+  /**
+   * Creates the {@link ActionHandler} to be used by the store.
+   */
+  public static newHandler(): ActionHandler<BoardState, RootState> {
+    return (ctx: ActionContext<BoardState, RootState>, p: BoardId): void => {
+      new SubscribeToColumnAddedAction(ctx, p).execute();
+    };
+  }
+}

--- a/web/client-js/src/store/board/mutations/add-column-mutation.ts
+++ b/web/client-js/src/store/board/mutations/add-column-mutation.ts
@@ -26,23 +26,19 @@
 
 import { Mutation } from "vuex";
 import { BoardState } from "@/store/board/state/board-state";
-import { BoardCreated } from "@/store/board/aliases";
+
+type Column = proto.spine_examples.kanban.Column;
 
 /**
- * Mutates the local {@linkplain BoardState board state} in response
- * to the {@link BoardCreated} event.
+ * Adds the provided column to the board in the {@linkplain BoardState local state}.
  */
-export default class BoardCreatedMutation {
+export default class AddColumnMutation {
   /**
    * Creates the mutation handler to be used by the store.
-   *
-   * Adds the board extracted from the {@link BoardCreated} event to the
-   * {@linkplain BoardState local state}.
    */
   public static newHandler(): Mutation<BoardState> {
-    return (s: BoardState, e: BoardCreated) => {
-      s.board = new proto.spine_examples.kanban.BoardView();
-      s.board.setId(e.getBoard());
+    return (s: BoardState, c: Column) => {
+      s.board?.addColumn(c);
     };
   }
 }

--- a/web/client-js/src/store/board/mutations/add-column-mutation.ts
+++ b/web/client-js/src/store/board/mutations/add-column-mutation.ts
@@ -31,6 +31,8 @@ type Column = proto.spine_examples.kanban.Column;
 
 /**
  * Adds the provided column to the board in the {@linkplain BoardState local state}.
+ *
+ * If the column is already present in the state, it is not added.
  */
 export default class AddColumnMutation {
   /**
@@ -38,7 +40,9 @@ export default class AddColumnMutation {
    */
   public static newHandler(): Mutation<BoardState> {
     return (s: BoardState, c: Column) => {
-      s.board?.addColumn(c);
+      if (!s.board?.getColumnList().includes(c)) {
+        s.board!.addColumn(c);
+      }
     };
   }
 }

--- a/web/client-js/src/store/board/mutations/index.ts
+++ b/web/client-js/src/store/board/mutations/index.ts
@@ -34,11 +34,12 @@ import AddColumnMutation from "@/store/board/mutations/add-column-mutation";
  */
 export const MutationType = {
   /**
-   * Adds the provided column to the board in the {@linkplain BoardState local state}.
+   * Sets the board in the {@linkplain BoardState local state} to the provided value.
    */
   SET_BOARD: "setBoard",
+
   /**
-   * Sets the board in the {@linkplain BoardState local state} to the provided value.
+   * Adds the provided column to the board in the {@linkplain BoardState local state}.
    */
   ADD_COLUMN: "addColumn",
 };

--- a/web/client-js/src/store/board/mutations/index.ts
+++ b/web/client-js/src/store/board/mutations/index.ts
@@ -26,29 +26,27 @@
 
 import { MutationTree } from "vuex";
 import { BoardState } from "@/store/board/state/board-state";
-import BoardCreatedMutation from "@/store/board/mutations/board-created-mutation";
-import ColumnAddedMutation from "@/store/board/mutations/column-added-mutation";
+import SetBoardMutation from "@/store/board/mutations/set-board-mutation";
+import AddColumnMutation from "@/store/board/mutations/add-column-mutation";
 
 /**
  * Defines mutation types of the local {@linkplain BoardState board state}.
  */
 export const MutationType = {
   /**
-   * Adds the board extracted from the {@link BoardCreated} event to the state.
+   * Adds the provided column to the board in the {@linkplain BoardState local state}.
    */
-  BOARD_CREATED: "boardCreated",
-
+  SET_BOARD: "setBoard",
   /**
-   * Adds the column extracted from the {@link ColumnAdded} event to the board stored
-   * in the state.
+   * Sets the board in the {@linkplain BoardState local state} to the provided value.
    */
-  COLUMN_ADDED: "columnAdded",
+  ADD_COLUMN: "addColumn",
 };
 
 /**
  * Exposes mutations of the local {@linkplain BoardState board state}.
  */
 export const mutations: MutationTree<BoardState> = {
-  [MutationType.BOARD_CREATED]: BoardCreatedMutation.newHandler(),
-  [MutationType.COLUMN_ADDED]: ColumnAddedMutation.newHandler(),
+  [MutationType.SET_BOARD]: SetBoardMutation.newHandler(),
+  [MutationType.ADD_COLUMN]: AddColumnMutation.newHandler(),
 };

--- a/web/client-js/src/store/board/mutations/set-board-mutation.ts
+++ b/web/client-js/src/store/board/mutations/set-board-mutation.ts
@@ -26,27 +26,18 @@
 
 import { Mutation } from "vuex";
 import { BoardState } from "@/store/board/state/board-state";
-import { ColumnAdded } from "@/store/board/aliases";
+import { Board } from "@/store/board/aliases";
 
 /**
- * Mutates the local {@linkplain BoardState board state} in response
- * to the {@link ColumnAdded} event.
+ * Sets the board in the {@linkplain BoardState local state} to the provided value.
  */
-export default class ColumnAddedMutation {
+export default class SetBoardMutation {
   /**
    * Creates the mutation handler to be used by the store.
-   *
-   * Adds the column extracted from the {@link ColumnAdded} event to the board stored
-   * in the {@linkplain BoardState local state}.
    */
   public static newHandler(): Mutation<BoardState> {
-    return (s: BoardState, e: ColumnAdded) => {
-      const column = new proto.spine_examples.kanban.Column();
-      column.setId(e.getColumn());
-      column.setBoard(e.getBoard());
-      column.setName(e.getName());
-      column.setPosition(e.getPosition());
-      s.board!.addColumn(column);
+    return (s: BoardState, b: Board) => {
+      s.board = b;
     };
   }
 }

--- a/web/client-js/src/views/BoardView.vue
+++ b/web/client-js/src/views/BoardView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="board" id="columns">
+  <div v-if="board" id="board">
     <KanbanColumn
       v-for="(column, $columnIndex) of board.getColumnList()"
       :key="$columnIndex"
@@ -15,9 +15,6 @@
       />
     </div>
   </div>
-  <div v-else id="add-board">
-    <button v-on:click="createBoard()">Add a board</button>
-  </div>
 </template>
 
 <script lang="ts">
@@ -28,7 +25,7 @@ import AddColumnForm from "@/components/board/AddColumnForm.vue";
 import KanbanColumn from "@/components/board/KanbanColumn.vue";
 import { ActionType } from "@/store/board/actions";
 
-const { mapState, mapActions } = createNamespacedHelpers(Board.MODULE_NAME);
+const { mapActions, mapState } = createNamespacedHelpers(Board.MODULE_NAME);
 
 /**
  * Displays the Kanban board.
@@ -41,11 +38,21 @@ export default defineComponent({
       addColumnFormOpened: false,
     };
   },
+  created() {
+    const boardUuid = this.$route.params.id as string;
+    const boardId = new proto.spine_examples.kanban.BoardId();
+    boardId.setUuid(boardUuid);
+    this.fetchBoard(boardId);
+    this.subscribeToColumnAdded(boardId);
+  },
   computed: {
     ...mapState(["board"]),
   },
   methods: {
-    ...mapActions([ActionType.CREATE_BOARD]),
+    ...mapActions({
+      subscribeToColumnAdded: ActionType.Subscription.SUBSCRIBE_TO_COLUMN_ADDED,
+      fetchBoard: ActionType.Query.FETCH_BOARD,
+    }),
     openAddColumnForm() {
       this.addColumnFormOpened = true;
     },
@@ -57,7 +64,7 @@ export default defineComponent({
 </script>
 
 <style scoped>
-#columns {
+#board {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
@@ -66,11 +73,6 @@ export default defineComponent({
   overflow-x: auto;
 }
 
-#add-board {
-  padding-left: 30px;
-}
-
-#add-board button,
 #add-column button {
   all: unset;
   display: flex;
@@ -83,7 +85,6 @@ export default defineComponent({
   margin: 0.5rem;
 }
 
-#add-board button:hover,
 #add-column button:hover {
   background-color: #cdd2d4;
   color: #4d4d4d;

--- a/web/client-js/src/views/CreateBoardView.vue
+++ b/web/client-js/src/views/CreateBoardView.vue
@@ -1,0 +1,73 @@
+<!--
+  - Copyright 2022, TeamDev. All rights reserved.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  - http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Redistribution and use in source and/or binary forms, with or without
+  - modification, must retain the above copyright notice and the following
+  - disclaimer.
+  -
+  - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  - "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  - LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  - A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  - OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  - SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  - LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  - DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  - THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  - (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  - OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<template>
+  <div id="add-board">
+    <button v-on:click="createBoard()">Add a board</button>
+  </div>
+</template>
+<script lang="ts">
+import { createNamespacedHelpers } from "vuex";
+import Board from "@/store/board";
+import { defineComponent } from "vue";
+import { ActionType } from "@/store/board/actions";
+
+const { mapActions } = createNamespacedHelpers(Board.MODULE_NAME);
+
+/**
+ * Creates a Kanban board.
+ */
+export default defineComponent({
+  name: "CreateBoardView",
+  methods: {
+    ...mapActions({
+      createBoard: ActionType.Command.CREATE_BOARD,
+    }),
+  },
+});
+</script>
+<style>
+#add-board {
+  padding-left: 30px;
+}
+
+#add-board button {
+  all: unset;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 30px;
+  width: 250px;
+  background-color: #e2e4e6;
+  border-radius: 0.1rem;
+  margin: 0.5rem;
+}
+
+#add-board button:hover {
+  background-color: #cdd2d4;
+  color: #4d4d4d;
+}
+</style>


### PR DESCRIPTION
Before the PR, the interaction with the server was limited to sending commands and receiving events. Considering that, boards were "temporal" because there was no way to interact with the same board after a page refresh. This PR adds action to fetch the board by the ID and separates `BoardView` into two separate views: 
- `CreateBoardView` for the board creation a.k.a the starting page;
- `BoardView` is the view for the specific board.

Also, the PR modifies mutations as they were dependent on events and, therefore, not reusable when queries come into the picture. 

Here is a demo:
![demo](https://user-images.githubusercontent.com/54888768/196157201-acb30368-8561-4e16-aafd-f1619cb235b5.gif)

