### PR TITLE
Fix column movement

### DIFF
--- a/server/src/main/java/io/spine/examples/kanban/server/board/BoardAggregate.java
+++ b/server/src/main/java/io/spine/examples/kanban/server/board/BoardAggregate.java
@@ -295,13 +295,17 @@ final class BoardAggregate extends Aggregate<BoardId, Board, Board.Builder> {
             ImmutableList.Builder<ColumnMovedOnBoard> movedColumns = new ImmutableList.Builder<>();
 
             ColumnPosition current = rightTo(from);
-            while (!current.equals(to)) {
-                ColumnPosition newPosition = leftTo(current);
-                movedColumns.add(BoardAggregate.this.moveColumn(current, newPosition));
+            while(!current.equals(to)) {
+                movedColumns.add(shiftColumnLeft(current));
                 current = rightTo(current);
             }
+            movedColumns.add(shiftColumnLeft(to));
 
             return movedColumns.build();
+        }
+
+        private ColumnMovedOnBoard shiftColumnLeft(ColumnPosition position) {
+            return BoardAggregate.this.moveColumn(position, leftTo(position));
         }
 
         /**
@@ -326,13 +330,17 @@ final class BoardAggregate extends Aggregate<BoardId, Board, Board.Builder> {
             ImmutableList.Builder<ColumnMovedOnBoard> movedColumns = new ImmutableList.Builder<>();
 
             ColumnPosition current = leftTo(from);
-            while (!current.equals(to)) {
-                ColumnPosition newPosition = rightTo(current);
-                movedColumns.add(BoardAggregate.this.moveColumn(current, newPosition));
+            while(!current.equals(to)) {
+                movedColumns.add(shiftColumnRight(current));
                 current = leftTo(current);
             }
+            movedColumns.add(shiftColumnRight(to));
 
             return movedColumns.build();
+        }
+
+        private ColumnMovedOnBoard shiftColumnRight(ColumnPosition position) {
+            return BoardAggregate.this.moveColumn(position, rightTo(position));
         }
     }
 }

--- a/server/src/main/java/io/spine/examples/kanban/server/view/BoardProjection.java
+++ b/server/src/main/java/io/spine/examples/kanban/server/view/BoardProjection.java
@@ -91,10 +91,11 @@ public final class BoardProjection
     }
 
     private int indexOf(ColumnId c) {
-        return IntStream.rangeClosed(0, state().getColumnCount() - 1)
+        return IntStream.range(0, state().getColumnCount())
                         .filter(i -> state().getColumn(i).getId().equals(c))
                         .findFirst().orElse(-1);
     }
+
     @Subscribe
     void updated(Card card) {
         int index = state().getCardList()

--- a/server/src/main/java/io/spine/examples/kanban/server/view/BoardProjection.java
+++ b/server/src/main/java/io/spine/examples/kanban/server/view/BoardProjection.java
@@ -30,12 +30,15 @@ import io.spine.core.Subscribe;
 import io.spine.examples.kanban.BoardId;
 import io.spine.examples.kanban.Card;
 import io.spine.examples.kanban.Column;
+import io.spine.examples.kanban.ColumnId;
 import io.spine.examples.kanban.event.BoardCreated;
 import io.spine.examples.kanban.event.ColumnAdditionRequested;
 import io.spine.examples.kanban.event.ColumnMovedOnBoard;
 import io.spine.examples.kanban.event.ColumnPlaced;
 import io.spine.examples.kanban.view.BoardView;
 import io.spine.server.projection.Projection;
+
+import java.util.stream.IntStream;
 
 /**
  * Builds display information for a board.
@@ -74,16 +77,24 @@ public final class BoardProjection
 
     @Subscribe
     void on(ColumnMovedOnBoard e) {
-        Column column = state()
-                .getColumn(e.getFrom().zeroBasedIndex())
-                .toBuilder()
-                .setPosition(e.getTo())
-                .vBuild();
-
-        builder().removeColumn(e.getFrom().zeroBasedIndex())
-                 .addColumn(column.getPosition().zeroBasedIndex(), column);
+        int index = indexOf(e.getColumn());
+        int newIndex = e.getTo().zeroBasedIndex();
+        if (index != newIndex) {
+            Column column = state()
+                    .getColumn(index)
+                    .toBuilder()
+                    .setPosition(e.getTo())
+                    .vBuild();
+            builder().removeColumn(index)
+                     .addColumn(column.getPosition().zeroBasedIndex(), column);
+        }
     }
 
+    private int indexOf(ColumnId c) {
+        return IntStream.rangeClosed(0, state().getColumnCount() - 1)
+                        .filter(i -> state().getColumn(i).getId().equals(c))
+                        .findFirst().orElse(-1);
+    }
     @Subscribe
     void updated(Card card) {
         int index = state().getCardList()


### PR DESCRIPTION
This PR fixes a few issues with the [recently added](https://github.com/spine-examples/kanban/pull/135) functionality for moving columns. 

The first issue is improperly updating the `Board` projection's state. During a column movement process, many `ColumnMovedOnBoard` events are emitted. However, only one event out of all emitted in a single "transaction" is modifying the state of the `Board` aggregate and projection resulting in all other events being "irrelevant" as the state is already right. To avoid messing the column order up when all "irrelevant" events are applied to the aggregate's or projection's state, the applier should check whether the column from an arrived `ColumnMovedOnBoard` is already at the expected place instead of blindly moving the column placed at the `from` position to the `to` position. Before the PR, only the aggregate correctly applied the described algorithm, when the projection did it improperly. 

Another issue is that shifting columns during movement produces one `ColumnMovedOnBoard` event less than should. In other words, one column is not shifted to its new position. The state of the `Board` aggregate was updated correctly due to reasons described in the previous paragraph, however, the state of `Column` aggregates became incoherent with the `Board` and, therefore, invalid.